### PR TITLE
DOCSP-11755: update redirect to point to 7.1

### DIFF
--- a/config/redirects
+++ b/config/redirects
@@ -1,6 +1,6 @@
 define: base https://docs.mongodb.com/mongoid
 
 symlink: upcoming -> master
-symlink: current -> 7.0
+symlink: current -> 7.1
 
 raw: mongoid/ -> ${base}/current


### PR DESCRIPTION
JIRA:
https://jira.mongodb.org/browse/DOCSP-11755

Updated redirects file to default to 7.1 when "current" accessed.