### PR TITLE
DOP-3400: migrate build system to snooty :tada:

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,4 @@
+[submodule "mongoid"]
+	path = mongoid
+	url = https://github.com/mongodb/mongoid.git
+	branch = master

--- a/snooty.toml
+++ b/snooty.toml
@@ -1,0 +1,4 @@
+name = "mongoid"
+title = "Mongoid"
+
+intersphinx = ["https://www.mongodb.com/docs/manual/objects.inv"]

--- a/worker.sh
+++ b/worker.sh
@@ -1,0 +1,1 @@
+"build-and-stage-next-gen"


### PR DESCRIPTION
Important note: we have done **nothing** to handle the generation of the API docs using yarn. We will need to coordinate with the mongoid engineers to sort out a solution to the generation of those API docs since it doesn't really make sense for it to go through the Autobuilder / be part of this repo anymore.

Once this PR is merged, the master branch of docs-mongoid will be deployable using the /deploy command and build with snooty.
