### PR TITLE
Fix QA site prefix

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ DOTCOM_STAGING_BUCKET=docs-mongodb-org-dotcomstg
 DOTCOM_PRODUCTION_URL="https://mongodb.com"
 DOTCOM_PRODUCTION_BUCKET=docs-mongodb-org-dotcomprd
 DOTCOM_PREFIX=docs/mongoid
-DOTCOM_STGPREFIX=docs/mongoid
+DOTCOM_STGPREFIX=docs-qa/mongoid
 
 # Parse our published-branches configuration file to get the name of
 # the current "stable" branch. This is weird and dumb, yes.


### PR DESCRIPTION
The staging site prefix currently points to the wrong url. This PR fixes the URL which allows anyone building with legacy tooling to get the correct staging url when running the stage target.