### PR TITLE
DOCSP-39124: Use upcoming instead of master

### DIFF
--- a/config/redirects
+++ b/config/redirects
@@ -5,5 +5,4 @@ define: master https://www.mongodb.com/docs/mongoid/master
 symlink: current -> 8.1
 
 raw: ${prefix}/ -> ${base}/current/
-
 raw: ${prefix}/current/release-notes/mongoid-7.0 -> ${base}/current/

--- a/config/redirects
+++ b/config/redirects
@@ -1,8 +1,10 @@
 define: prefix docs/mongoid
 define: base https://www.mongodb.com/docs/mongoid
-define: master https://www.mongodb.com/docs/mongoid/master
+define: versions 8.1 upcoming
 
 symlink: current -> 8.1
 
 raw: ${prefix}/ -> ${base}/current/
+raw: ${prefix}/master -> ${base}/upcoming/
+
 raw: ${prefix}/current/release-notes/mongoid-7.0 -> ${base}/current/

--- a/config/redirects
+++ b/config/redirects
@@ -2,29 +2,8 @@ define: prefix docs/mongoid
 define: base https://www.mongodb.com/docs/mongoid
 define: master https://www.mongodb.com/docs/mongoid/master
 
-symlink: upcoming -> master
 symlink: current -> 8.1
 
 raw: ${prefix}/ -> ${base}/current/
-raw: ${prefix}/upcoming -> ${master}/
 
-raw: ${prefix}/upcoming/tutorials/getting-started-sinatra -> ${master}/tutorials/getting-started-sinatra/
-raw: ${prefix}/upcoming/tutorials/getting-started-rails -> ${master}/tutorials/getting-started-rails/
-raw: ${prefix}/upcoming/tutorials/mongoid-installation -> ${master}/tutorials/mongoid-installation/
-raw: ${prefix}/upcoming/tutorials/mongoid-configuration -> ${master}/tutorials/mongoid-configuration/
-raw: ${prefix}/upcoming/tutorials/mongoid-documents -> ${master}/tutorials/mongoid-documents/
-raw: ${prefix}/upcoming/tutorials/mongoid-persistence -> ${master}/tutorials/mongoid-persistence/
-raw: ${prefix}/upcoming/tutorials/mongoid-queries -> ${master}/tutorials/mongoid-queries/
-raw: ${prefix}/upcoming/tutorials/mongoid-relations -> ${master}/tutorials/mongoid-relations/
-raw: ${prefix}/upcoming/tutorials/mongoid-nested-attributes -> ${master}/tutorials/mongoid-nested-attributes/
-raw: ${prefix}/upcoming/tutorials/mongoid-callbacks -> ${master}/tutorials/mongoid-callbacks/
-raw: ${prefix}/upcoming/tutorials/mongoid-validation -> ${master}/tutorials/mongoid-validation/
-raw: ${prefix}/upcoming/tutorials/mongoid-indexes -> ${master}/tutorials/mongoid-indexes/
-raw: ${prefix}/upcoming/tutorials/sharding -> ${master}/tutorials/sharding/
-raw: ${prefix}/upcoming/tutorials/mongoid-sessions -> ${master}/tutorials/mongoid-sessions/
-raw: ${prefix}/upcoming/tutorials/mongoid-transactions -> ${master}/tutorials/mongoid-transactions/
-raw: ${prefix}/upcoming/tutorials/mongoid-rails -> ${master}/tutorials/mongoid-rails/
-raw: ${prefix}/upcoming/tutorials/mongoid-upgrade -> ${master}/tutorials/mongoid-upgrade/
-raw: ${prefix}/upcoming/additional-resources -> ${master}/additional-resources/
-raw: ${prefix}/upcoming/ecosystem -> ${master}/ecosystem/
 raw: ${prefix}/current/release-notes/mongoid-7.0 -> ${base}/current/


### PR DESCRIPTION
JIRA - https://jira.mongodb.org/browse/DOCSP-39124
Redirects:

Redirect 301 /docs/mongoid/ https://www.mongodb.com/docs/mongoid/current/
Redirect 301 /docs/mongoid/master https://www.mongodb.com/docs/mongoid/upcoming/
Redirect 301 /docs/mongoid/current/release-notes/mongoid-7.0 https://www.mongodb.com/docs/mongoid/current/
