### PR TITLE
DOCSP-38361 - Fix empty pages

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "mongoid"]
 	path = mongoid
-	url = https://github.com/mongodb/mongoid.git
-	branch = master
+	url = https://github.com/mongoKart/mongoid.git
+	branch = docsp-38361-fix-empty-pages


### PR DESCRIPTION
This PR adds text to empty top-level pages to improve SEO. This is a stopgap solution until the Docs team is able to reorganize this content (i.e., don't go nuts trying to optimize this text)

**Note:** Because these changes are for SEO improvement, this PR doesn't make these pages navigable from the TOC.

Jira: https://jira.mongodb.org/browse/DOCSP-38361
Staging: https://preview-mongodbmongokart.gatsbyjs.io/mongoid/docsp-38361-fix-empty-pages/