### PR TITLE
DOCSP-46474: Remove broken link to deprecated comment operator

### DIFF
--- a/source/reference/associations.txt
+++ b/source/reference/associations.txt
@@ -710,7 +710,6 @@ The following operators are supported:
 - :manual:`$regex </reference/operator/query/regex/>` (``$options`` field
   is only supported when the ``$regex`` argument is a string)
 - :manual:`Bitwise operators </reference/operator/query-bitwise/>`
-- :manual:`$comment </reference/operator/query/comment/>`
 
 For example, using the model definitions just given, we could query
 tours on a loaded band:


### PR DESCRIPTION
Per server team, the $comment query operator support was dropped in v5.1, so this broken link can be deleted.

# Pull Request Info

[PR Reviewing Guidelines](https://github.com/mongodb/docs-mongoid/blob/master/REVIEWING.md)

JIRA - <https://jira.mongodb.org/browse/DOCSP-46474>
Staging - <https://deploy-preview-85--docs-mongoid.netlify.app/reference/associations/>

## Self-Review Checklist

- [x] Is this free of any warnings or errors in the RST?
