### PR TITLE
DOCSP-46786 fixed typo

### DIFF
--- a/source/security/encryption.txt
+++ b/source/security/encryption.txt
@@ -236,8 +236,8 @@ The following limitations apply when using CSFLE with {+odm+}:
 
 - {+odm+} does not support encryption of ``embeds_many`` associations.
 - If you use the ``:key_name_field`` option, you must encrypt the field by using
-  a non-deterministic algorithm. To encrypt your field deterministically, you must
-  specify the ``:key_id`` option instead.
+  a non-deterministic algorithm. To encrypt your field deterministically, you 
+  must specify the ``:key_id`` option instead.
 - The limitations listed on the :manual:`CSFLE Limitations
   </core/csfle/reference/limitations/>` page in the MongoDB {+server-manual+}
   also apply to {+odm+}.

--- a/source/security/encryption.txt
+++ b/source/security/encryption.txt
@@ -245,7 +245,7 @@ The following limitations apply when using CSFLE with {+odm+}:
 Working with Data
 -----------------
 
-Usually, automatic CSLFE works transparently in your application. After
+Usually, automatic CSFLE works transparently in your application. After
 your application is configured for CSFLE, you can create documents as usual and {+odm+}
 automatically encrypts and decrypts them according to your configuration.
 


### PR DESCRIPTION
Fixed typo where CSFLE is referred to as 'CSLFE'

Jira: [DOCSP-46786](https://jira.mongodb.org/browse/DOCSP-46786)

Preview: 