### PR TITLE
DOCSP-46743 Too Short Titles: Tutorials redirect

### DIFF
--- a/config/redirects
+++ b/config/redirects
@@ -41,6 +41,7 @@ raw: ${prefix}/stable -> ${base}/current/
 [v9.0-*]: ${prefix}/${version}/reference/compatibility/ -> ${base}/${version}/compatibility/
 [v9.0-*]: ${prefix}/${version}/reference/configuration/ -> ${base}/${version}/configuration/
 [v9.0-*]: ${prefix}/${version}/reference/rails-integration/ -> ${base}/${version}/integrations-tools/rails-integration/
+[v9.0-*]: ${prefix}/${version}/tutorials/ -> ${base}/${version}/
 [v9.0-*]: ${prefix}/${version}/tutorials/getting-started-sinatra/ -> ${base}/${version}/quick-start-sinatra/
 [v9.0-*]: ${prefix}/${version}/tutorials/getting-started-rails7/ -> ${base}/${version}/quick-start-rails/
 [v9.0-*]: ${prefix}/${version}/tutorials/getting-started-rails6/ -> ${base}/${version}/quick-start-rails/


### PR DESCRIPTION
# Pull Request Info

[PR Reviewing Guidelines](https://github.com/mongodb/docs-mongoid/blob/master/REVIEWING.md)

JIRA - <https://jira.mongodb.org/browse/DOCSP-46743>

The page doesn't seem to need to be accessible (https://www.mongodb.com/docs/mongoid/current/tutorials/), so I created a redirect instead of making the title longer.

### Staging Links
<!-- start insert-links -->
No pages to preview
<!-- end insert-links -->

## Self-Review Checklist

- [x] Is this free of any warnings or errors in the RST?
- [x] Did you run a spell-check?
- [x] Did you run a grammar-check?
- [x] Are all the links working?
- [x] Are the [facets and meta keywords](https://wiki.corp.mongodb.com/display/DE/Docs+Taxonomy) accurate?
