### PR TITLE
Add missing meta descriptions

### DIFF
--- a/source/index.txt
+++ b/source/index.txt
@@ -5,6 +5,9 @@
 {+odm+}: The ODM for MongoDB in Ruby
 ================================
 
+.. meta::
+   :description: Explore Mongoid, the Ruby ODM for MongoDB, with guides on connecting, configuring, and interacting with data in Ruby applications.
+
 .. toctree::
    :titlesonly:
  


### PR DESCRIPTION
Adds missing meta descriptions generated by the Education AI Team\n\nSOURCE: https://docs.google.com/spreadsheets/d/1fdrjF4Ms9fMl96zLiLGsYD_V38rTfPLuKs5VQk4vz6E/edit?gid=1166644539