### PR TITLE
MONGOID-5714 - Fix "embedded callbacks removed" in 9.0 release notes

### DIFF
--- a/source/whats-new.txt
+++ b/source/whats-new.txt
@@ -152,7 +152,7 @@ removed.
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 {+odm+} v8.x and older allow user to define ``around_*`` callbacks for embedded
-documents. Starting in v9.0, by default, these callbacks are ignored and will
+documents. Starting in v9.0, by default these callbacks are ignored and will
 not be executed. A warning will be printed to the console if such callbacks are defined.
 
 If you want to restore the old behavior, you can set

--- a/source/whats-new.txt
+++ b/source/whats-new.txt
@@ -148,6 +148,23 @@ Removal of Deprecated Class ``Mongoid::Errors::InvalidStorageParent``
 The deprecated class ``{+odm+}::Errors::InvalidStorageParent`` has been
 removed.
 
+``around_*`` Callbacks for Embedded Documents are Ignored by Default
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+{+odm+} v8.x and older allow user to define ``around_*`` callbacks for embedded
+documents. Starting in v9.0, by default, these callbacks are ignored and will
+not be executed. A warning will be printed to the console if such callbacks are defined.
+
+If you want to restore the old behavior, you can set
+``Mongoid.around_callbacks_for_embeds`` to true in your application.
+
+.. note::
+
+   Enabling ``around_*`` callbacks for embedded documents is not recommended
+   as it may cause ``SystemStackError`` exceptions when a document has many
+   embedded documents. See `MONGOID-5658
+   <https://jira.mongodb.org/browse/MONGOID-5658>`__ for more details.
+
 ``for_js`` Method is Deprecated
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/source/whats-new.txt
+++ b/source/whats-new.txt
@@ -148,23 +148,6 @@ Removal of Deprecated Class ``Mongoid::Errors::InvalidStorageParent``
 The deprecated class ``{+odm+}::Errors::InvalidStorageParent`` has been
 removed.
 
-``around_*`` Callbacks for Embedded Documents are Ignored
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-{+odm+} v8.x and older allow user to define ``around_*`` callbacks for embedded
-documents. Starting in v9.0, these callbacks are ignored and will not be executed.
-A warning will be printed to the console if such callbacks are defined.
-
-If you want to restore the old behavior, you can set
-``Mongoid.around_embedded_document_callbacks`` to true in your application.
-
-.. note::
-
-   Enabling ``around_*`` callbacks for embedded documents is not recommended
-   as it may cause ``SystemStackError`` exceptions when a document has many
-   embedded documents. See `MONGOID-5658
-   <https://jira.mongodb.org/browse/MONGOID-5658>`__ for more details.
-
 ``for_js`` Method is Deprecated
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 


### PR DESCRIPTION
The name of the config is "around_callbacks_for_embeds", but the release notes mistakenly call it "around_embedded_document_callbacks".